### PR TITLE
Fix Purple Room scroll bug, add dark mode to subpages, more polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <!-- fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Vibur&family=Amiri&family=Josefin+Sans:wght@100&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Amiri&family=Josefin+Sans:wght@100&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap" rel="stylesheet">
 
   <title>Caradec Bisesar | Developer, Photographer, Coffee Consumer</title>
   <meta property="og:title" content="Caradec Bisesar | Developer, Photographer, Coffee Consumer">

--- a/src/assets/cup-top-view-iced.svg
+++ b/src/assets/cup-top-view-iced.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="96" fill="#e8e4de" opacity=".35"/>
+  <circle cx="100" cy="100" r="88" fill="#caa06a"/>
+  <circle cx="100" cy="100" r="88" fill="none" stroke="#8a6a42" stroke-width="3" opacity=".5"/>
+  <g fill="#f4efe8" opacity=".92">
+    <rect x="52" y="58" width="34" height="34" rx="9" transform="rotate(-18 69 75)"/>
+    <rect x="108" y="46" width="30" height="30" rx="8" transform="rotate(12 123 61)"/>
+    <rect x="118" y="98" width="36" height="36" rx="9" transform="rotate(-8 136 116)"/>
+    <rect x="58" y="112" width="28" height="28" rx="8" transform="rotate(22 72 126)"/>
+    <rect x="92" y="86" width="26" height="26" rx="7" transform="rotate(35 105 99)"/>
+  </g>
+  <g stroke="#7a5330" stroke-width="1.5" opacity=".3" fill="none">
+    <rect x="52" y="58" width="34" height="34" rx="9" transform="rotate(-18 69 75)"/>
+    <rect x="108" y="46" width="30" height="30" rx="8" transform="rotate(12 123 61)"/>
+    <rect x="118" y="98" width="36" height="36" rx="9" transform="rotate(-8 136 116)"/>
+    <rect x="58" y="112" width="28" height="28" rx="8" transform="rotate(22 72 126)"/>
+    <rect x="92" y="86" width="26" height="26" rx="7" transform="rotate(35 105 99)"/>
+  </g>
+  <path d="M150 34 L172 8" stroke="#f4efe8" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import '../css/chat.css'
 import {
   CHAT_OPENERS,
   CHAT_MIDDLE,
+  CHAT_RUNNING,
   CHAT_PHOTOGRAPHY,
   CHAT_CATS,
   HOT_PHRASES,
@@ -12,7 +13,9 @@ import {
   type ChatQA,
 } from '../content/chat'
 import { ENTRIES, TOOLBOX, EDUCATION } from '../content/resume'
+import { useLights } from '../hooks/useLights'
 import cupArt from '../assets/cup-top-view.svg'
+import cupArtIced from '../assets/cup-top-view-iced.svg'
 import cameraPhoto from '../assets/camera.jpg'
 import pairPhoto from '../assets/pair.jpg'
 
@@ -37,7 +40,7 @@ function ChatSection({ items }: { items: ChatQA[] }) {
 }
 
 function App() {
-  const [lights, setLights] = useState(true)
+  const [lights, setLights] = useLights()
   const [atEnd, setAtEnd] = useState(false)
   const [noMotion] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -47,15 +50,13 @@ function App() {
     if (!root || noMotion) return
 
     const hero = root.querySelector<HTMLElement>('.hero')
-    const pull = root.querySelector<HTMLElement>('.pull-scene')
-    const pullSticky = root.querySelector<HTMLElement>('.pull-sticky')
     const band = root.querySelector<HTMLElement>('.band')
     const cupFill = root.querySelector<SVGRectElement>('.cup .fill')
     const cupNote = root.querySelector<HTMLElement>('.cup .cup-note')
     const paperwork = root.querySelector<HTMLElement>('#paperwork')
     const contact = root.querySelector<HTMLElement>('#contact')
     const navLinks = root.querySelectorAll<HTMLAnchorElement>('nav.chat-nav ul a')
-    if (!hero || !pull || !pullSticky || !band || !cupFill || !cupNote || !paperwork || !contact) return
+    if (!hero || !band || !cupFill || !cupNote || !paperwork || !contact) return
 
     const clamp01 = (v: number) => Math.max(0, Math.min(1, v))
     let ticking = false
@@ -66,10 +67,6 @@ function App() {
       const vh = window.innerHeight
 
       hero!.style.setProperty('--exit', clamp01(y / (vh * 0.75)).toFixed(3))
-
-      const pr = pull!.getBoundingClientRect()
-      const sceneProgress = clamp01(-pr.top / (pr.height - vh))
-      pullSticky!.style.setProperty('--pp', sceneProgress.toFixed(3))
 
       const br = band!.getBoundingClientRect()
       const bandProgress = clamp01((vh - br.top) / (vh + br.height))
@@ -104,7 +101,7 @@ function App() {
         if (e.isIntersecting) { e.target.setAttribute('data-in', 'true'); revealIo.unobserve(e.target) }
       })
     }, { threshold: 0.16 })
-    root.querySelectorAll('.qa').forEach((el) => revealIo.observe(el))
+    root.querySelectorAll('.qa, .pull-scene').forEach((el) => revealIo.observe(el))
 
     const endIo = new IntersectionObserver((entries) => {
       entries.forEach((e) => setAtEnd(e.isIntersecting))
@@ -185,7 +182,7 @@ function App() {
           <svg className="ring-echo" viewBox="0 0 200 200">
             <circle cx="100" cy="100" r="88" fill="none" stroke="var(--coffee)" strokeWidth="8" opacity=".12" strokeDasharray="40 10 70 8 110 14" strokeLinecap="round" transform="rotate(40 100 100)"></circle>
           </svg>
-          <img className="cup-art" src={cupArt} alt="" />
+          <img className="cup-art" src={lights ? cupArt : cupArtIced} alt="" />
         </div>
         <div className="inner">
           <h1>
@@ -200,6 +197,7 @@ function App() {
 
       <ChatSection items={CHAT_OPENERS} />
       <ChatSection items={CHAT_MIDDLE} />
+      <ChatSection items={CHAT_RUNNING} />
 
       <div className="band">
         <img src={cameraPhoto} alt="Self portrait, camera raised, shot into a cafe mirror" />
@@ -219,10 +217,8 @@ function App() {
       <ChatSection items={CHAT_CATS} />
 
       <div className="pull-scene" id="pull">
-        <div className="pull-sticky">
-          <div className="pull-big serif">Enough small talk.</div>
-          <div className="pull-who">on to the paperwork</div>
-        </div>
+        <div className="pull-big serif">Enough small talk.</div>
+        <div className="pull-who">on to the paperwork</div>
       </div>
 
       <div className="paper-band">
@@ -280,14 +276,15 @@ function App() {
           <path className="outline" d="M10 14 h24 v28 a7 7 0 0 1 -7 7 h-10 a7 7 0 0 1 -7 -7 z"></path>
           <path className="outline" d="M34 21 h6 a6 6 0 0 1 0 13 h-6"></path>
         </svg>
-        <div className="serif">Need another cup? Let’s get in touch and grab one.</div>
-        <div className="closing-hint">I track it closer than I should: <a href="#/coffee">the log</a></div>
+        <div className="serif">Need another cup?</div>
+        <div className="serif">Let’s get in touch.</div>
         <ul>
           <li><a href="mailto:c.bisesar@gmail.com">c.bisesar@gmail.com</a></li>
           <li><a href="https://www.linkedin.com/in/caradec-bisesar-b3552443">LinkedIn</a></li>
           <li><a href="https://500px.com/cbisesar">500px</a></li>
           <li><a href="https://www.instagram.com/gr1mdrag0n/">Instagram</a></li>
         </ul>
+        <div className="closing-hint">(I also track every bag of coffee I buy: <a href="#/coffee">the log</a>)</div>
       </section>
 
       <footer className="chat-footer">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -195,6 +195,11 @@ function App() {
         </div>
       </section>
 
+      <div className="section-break" aria-hidden="true">
+        <span className="section-break-rule"></span>
+        <span className="section-break-label">small talk</span>
+      </div>
+
       <ChatSection items={CHAT_OPENERS} />
       <ChatSection items={CHAT_MIDDLE} />
       <ChatSection items={CHAT_RUNNING} />

--- a/src/components/Coffee.tsx
+++ b/src/components/Coffee.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import '../css/chat.css'
+import { useLights } from '../hooks/useLights'
 import CatSilhouette from './CatSilhouette'
 import { COFFEES, ROASTER_STATS, WISHLIST } from '../content/coffees'
 
@@ -11,6 +12,8 @@ function monthLabel(when: string) {
 }
 
 function Coffee() {
+  const [lights, setLights] = useLights()
+
   useEffect(() => {
     const previous = document.title
     document.title = 'The Log ☕ Caradec Bisesar'
@@ -38,7 +41,7 @@ function Coffee() {
   )
 
   return (
-    <div className="chat-page coffee-page">
+    <div className={'chat-page coffee-page' + (lights ? '' : ' lights-off')}>
       <nav className="chat-nav">
         <ul>
           <li><a href="#/">Small Talk</a></li>
@@ -47,6 +50,10 @@ function Coffee() {
         </ul>
       </nav>
       <a className="name-morph" href="#/">Caradec Bisesar</a>
+      <button className="cord" type="button" aria-label="Light switch" onClick={() => setLights((on) => !on)}>
+        <span className="line"></span>
+        <span className="knob"></span>
+      </button>
 
       <section className="coffee-wrap">
         <div className="coffee-kicker">the log</div>

--- a/src/components/Coffee.tsx
+++ b/src/components/Coffee.tsx
@@ -83,26 +83,29 @@ function Coffee() {
         </div>
 
         <div className="coffee-kicker log-kicker">every roaster</div>
-        <div className="coffee-log-scroll">
-          <table className="coffee-log-table">
-            <thead>
-              <tr>
-                <th>Roaster</th>
-                <th>Bags</th>
-                <th>Avg</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ROASTER_STATS.map((r) => (
-                <tr key={r[0]}>
-                  <td>{r[0]}</td>
-                  <td>{r[1]}</td>
-                  <td>{r[2]}</td>
+        <details className="coffee-log-details">
+          <summary>See all {ROASTER_STATS.length} roasters</summary>
+          <div className="coffee-log-scroll">
+            <table className="coffee-log-table">
+              <thead>
+                <tr>
+                  <th>Roaster</th>
+                  <th>Bags</th>
+                  <th>Avg</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {ROASTER_STATS.map((r) => (
+                  <tr key={r[0]}>
+                    <td>{r[0]}</td>
+                    <td>{r[1]}</td>
+                    <td>{r[2]}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
 
         <p className="coffee-more coffee-wishlist">
           <span className="wishlist-label">Still on the list: </span>

--- a/src/components/Kit.tsx
+++ b/src/components/Kit.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react'
 import '../css/chat.css'
+import { useLights } from '../hooks/useLights'
 import { KIT_CAMERA, KIT_COFFEE } from '../content/kit'
 
 function Kit() {
+  const [lights, setLights] = useLights()
+
   useEffect(() => {
     const previous = document.title
     document.title = 'The Kit ☕ Caradec Bisesar'
@@ -10,7 +13,7 @@ function Kit() {
   }, [])
 
   return (
-    <div className="chat-page coffee-page">
+    <div className={'chat-page coffee-page' + (lights ? '' : ' lights-off')}>
       <nav className="chat-nav">
         <ul>
           <li><a href="#/">Small Talk</a></li>
@@ -19,6 +22,10 @@ function Kit() {
         </ul>
       </nav>
       <a className="name-morph" href="#/">Caradec Bisesar</a>
+      <button className="cord" type="button" aria-label="Light switch" onClick={() => setLights((on) => !on)}>
+        <span className="line"></span>
+        <span className="knob"></span>
+      </button>
 
       <section className="coffee-wrap">
         <div className="coffee-kicker">the kit</div>

--- a/src/content/chat.ts
+++ b/src/content/chat.ts
@@ -52,6 +52,15 @@ export const CHAT_MIDDLE: ChatQA[] = [
   },
 ]
 
+export const CHAT_RUNNING: ChatQA[] = [
+  {
+    q: 'You mentioned running. How big a deal is that, really?',
+    a: [
+      'Bigger than I let on earlier. It’s less about racing and more about having twenty minutes where the only thing I’m optimizing is my pace. I track it the same way I track the coffee: distance, pace, the whole log. Some people meditate. I just go for a run and let my brain sort itself out.',
+    ],
+  },
+]
+
 export const CHAT_PHOTOGRAPHY: ChatQA[] = [
   {
     q: 'And the photography? Where did that start?',
@@ -71,23 +80,23 @@ export const CHAT_CATS: ChatQA[] = [
 ]
 
 export const HOT_PHRASES: [number, string][] = [
-  [0.92, 'just brewed'],
-  [0.8, 'still too hot'],
-  [0.65, 'take a sip'],
-  [0.45, 'halfway there'],
-  [0.3, 'getting cold'],
-  [0.18, 'second cup?'],
-  [0.07, 'cold. classic.'],
+  [0.92, 'fresh off the pour'],
+  [0.8, 'still dangerous'],
+  [0.65, 'prime drinking window'],
+  [0.45, 'halfway, no regrets'],
+  [0.3, 'cooling fast'],
+  [0.18, 'should have finished this'],
+  [0.07, 'lukewarm regret'],
 ]
-export const HOT_EMPTY = 'down to the dregs'
+export const HOT_EMPTY = 'the mug remembers better days'
 
 export const ICED_PHRASES: [number, string][] = [
-  [0.92, 'just poured'],
-  [0.8, 'ice still clinking'],
-  [0.65, 'take a sip'],
-  [0.45, 'halfway there'],
-  [0.3, 'mostly melted'],
-  [0.18, 'watered down'],
-  [0.07, 'all water now'],
+  [0.92, 'fresh over ice'],
+  [0.8, 'ice earning its keep'],
+  [0.65, 'prime drinking window'],
+  [0.45, 'halfway, no regrets'],
+  [0.3, 'ice losing the fight'],
+  [0.18, 'mostly melted'],
+  [0.07, 'basically water now'],
 ]
-export const ICED_EMPTY = 'just ice left'
+export const ICED_EMPTY = 'just ice, no shame'

--- a/src/content/kit.ts
+++ b/src/content/kit.ts
@@ -6,8 +6,10 @@ export const KIT_CAMERA: [string, string][] = [
 ]
 
 export const KIT_COFFEE: [string, string][] = [
+  ['Espresso', 'Breville Bambino Plus'],
   ['Grinder', 'Baratza Encore ESP'],
   ['Kettle', 'Fellow gooseneck'],
   ['Pour-over', 'Hario V60, and a Chemex for when company’s over'],
+  ['Immersion', 'AeroPress, and a small fleet of moka pots'],
   ['Scale', 'MHW-3BOMBER'],
 ]

--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -333,7 +333,11 @@ footer.chat-footer { border-top: 1px solid var(--rule); color: var(--faint); fon
 .hl-name { grid-column: 2; font-weight: 500; }
 .hl-meta { grid-column: 2; color: var(--faint); font-size: .85rem; }
 
-.coffee-log-scroll { overflow: auto; max-height: 560px; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); margin-bottom: 40px; }
+.coffee-log-details { margin-bottom: 40px; }
+.coffee-log-details summary { cursor: pointer; color: var(--soft); font-style: italic; font-family: 'Fraunces', serif; padding: 14px 0; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); }
+.coffee-log-details summary:hover { color: var(--ink); }
+.coffee-log-details[open] summary { border-bottom-color: transparent; }
+.coffee-log-scroll { overflow: auto; max-height: 560px; border-bottom: 1px solid var(--rule); margin-top: -1px; }
 .coffee-log-table { width: 100%; border-collapse: collapse; font-size: .88rem; }
 .coffee-log-table th { position: sticky; top: 0; background: var(--paper); text-align: left; font-weight: 600; padding: 8px 14px 8px 0; border-bottom: 1px solid var(--rule); color: var(--faint); font-size: .75rem; letter-spacing: .08em; text-transform: uppercase; white-space: nowrap; }
 .coffee-log-table td { padding: 7px 14px 7px 0; border-bottom: 1px solid var(--rule); color: var(--soft); white-space: nowrap; }

--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -99,7 +99,7 @@ nav.chat-nav a.active { color: var(--ink); border-bottom: 1.5px solid var(--acce
 
 /* ---------------------------------------------------------------- hero */
 
-.hero { min-height: 96vh; display: flex; flex-direction: column; justify-content: center; padding: 150px 48px 100px; max-width: 1150px; margin: 0 auto; position: relative; overflow: hidden; --exit: 0; }
+.hero { min-height: 96vh; display: flex; flex-direction: column; justify-content: center; padding: 150px 48px 70px; max-width: 1150px; margin: 0 auto; position: relative; overflow: hidden; --exit: 0; }
 .hero .inner { transform: translateY(calc(var(--exit) * -70px)); opacity: calc(1 - var(--exit) * 1.1); }
 .hero .ring { position: absolute; right: 8%; top: 10%; width: 260px; pointer-events: none;
   transform: translateY(calc(var(--exit) * 120px)); }
@@ -135,8 +135,19 @@ nav.chat-nav a.active { color: var(--ink); border-bottom: 1.5px solid var(--acce
 
 /* ---------------------------------------------------------------- chat */
 
-.chat { max-width: 820px; margin: 0 auto; padding: 60px 48px 40px; }
+.chat { max-width: 820px; margin: 0 auto; padding: 40px 48px 40px; }
 .chat + .chat { padding-top: 0; }
+
+.section-break {
+  display: flex; flex-direction: column; align-items: center; gap: 14px;
+  padding: 50px 0 30px; background: color-mix(in srgb, var(--ink) 3%, transparent);
+  transition: background .6s ease;
+}
+.lights-off .section-break { background: color-mix(in srgb, #000 20%, transparent); }
+.section-break-rule { width: 64px; height: 3px; border-radius: 3px;
+  background: linear-gradient(90deg, #2e8540, #2f5f8f, #6b2d6b, #c05b17); }
+.lights-off .section-break-rule { background: linear-gradient(90deg, #05F283, #056CF2, #7A26F0, #F38220); }
+.section-break-label { font-size: .78rem; letter-spacing: .28em; text-transform: uppercase; color: var(--faint); }
 @media (max-width: 640px) { .chat { padding: 36px 22px 30px; } }
 .qa { padding: 34px 0; }
 .qa .q, .qa .a { opacity: 0; }

--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -18,7 +18,6 @@ html {
   font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
   background: var(--paper); color: var(--ink);
   transition: background .6s ease, color .6s ease;
-  overflow-x: hidden;
 }
 .chat-page.lights-off {
   --paper: #091324; --ink: #eef3ff; --soft: rgba(255,255,255,.78); --faint: rgba(255,255,255,.5);
@@ -44,8 +43,7 @@ nav.chat-nav {
   font-family: 'Fraunces', serif; font-weight: 600; font-size: 1.75rem;
   line-height: 1; white-space: nowrap;
 }
-.lights-off .name-morph { font-family: 'Vibur', cursive; font-weight: 400;
-  text-shadow: 0 0 10px var(--glow), 0 0 26px #056CF2; }
+.lights-off .name-morph { text-shadow: 0 0 10px var(--glow), 0 0 26px #056CF2; }
 @media (max-width: 640px) { .name-morph { left: 20px; font-size: 1.35rem; } }
 nav.chat-nav ul { display: flex; gap: 34px; list-style: none; padding: 0 64px 0 0; margin: 0; }
 @media (max-width: 640px) { nav.chat-nav ul { padding-right: 34px; } }
@@ -101,7 +99,7 @@ nav.chat-nav a.active { color: var(--ink); border-bottom: 1.5px solid var(--acce
 
 /* ---------------------------------------------------------------- hero */
 
-.hero { min-height: 96vh; display: flex; flex-direction: column; justify-content: center; padding: 150px 48px 40px; max-width: 1150px; margin: 0 auto; position: relative; overflow: hidden; --exit: 0; }
+.hero { min-height: 96vh; display: flex; flex-direction: column; justify-content: center; padding: 150px 48px 100px; max-width: 1150px; margin: 0 auto; position: relative; overflow: hidden; --exit: 0; }
 .hero .inner { transform: translateY(calc(var(--exit) * -70px)); opacity: calc(1 - var(--exit) * 1.1); }
 .hero .ring { position: absolute; right: 8%; top: 10%; width: 260px; pointer-events: none;
   transform: translateY(calc(var(--exit) * 120px)); }
@@ -137,8 +135,9 @@ nav.chat-nav a.active { color: var(--ink); border-bottom: 1.5px solid var(--acce
 
 /* ---------------------------------------------------------------- chat */
 
-.chat { max-width: 820px; margin: 0 auto; padding: 30px 48px 40px; }
-@media (max-width: 640px) { .chat { padding: 20px 22px 30px; } }
+.chat { max-width: 820px; margin: 0 auto; padding: 60px 48px 40px; }
+.chat + .chat { padding-top: 0; }
+@media (max-width: 640px) { .chat { padding: 36px 22px 30px; } }
 .qa { padding: 34px 0; }
 .qa .q, .qa .a { opacity: 0; }
 .no-motion .qa .q, .no-motion .qa .a { opacity: 1; }
@@ -152,22 +151,25 @@ nav.chat-nav a.active { color: var(--ink); border-bottom: 1.5px solid var(--acce
 
 /* -------------------------------------------------------- purple room */
 
-.pull-scene { height: 150vh; position: relative; }
-.pull-sticky { position: sticky; top: 0; height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 0 48px;
-  background: #5c3c8c; transition: background .6s ease; }
-.lights-off .pull-sticky { background: #060d1a; }
+.pull-scene {
+  background: #5c3c8c; transition: background .6s ease;
+  padding: 160px 48px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center;
+}
+.lights-off .pull-scene { background: #060d1a; }
 .pull-big {
   font-family: 'Fraunces', serif; font-weight: 300; font-size: clamp(2.4rem, 6vw, 4.5rem); line-height: 1.3;
   max-width: 20ch; text-align: center; color: #faf7f2;
-  opacity: calc(var(--pp, 0) * 3); transform: scale(calc(.96 + var(--pp, 0) * .04));
+  opacity: 0; transform: translateY(18px); transition: opacity .8s ease, transform .8s ease;
 }
+.pull-scene[data-in] .pull-big { opacity: 1; transform: none; }
 .no-motion .pull-big { opacity: 1; transform: none; }
 .lights-off .pull-big { color: #7A26F0; text-shadow: 0 0 18px rgba(122,38,240,.45), 0 0 60px rgba(122,38,240,.3); }
 .pull-who { color: rgba(250,247,242,.65); font-size: .85rem; letter-spacing: .14em; text-transform: uppercase; margin-top: 26px;
-  opacity: calc((var(--pp, 0) - .75) * 4); }
+  opacity: 0; transition: opacity .8s .25s ease; }
+.pull-scene[data-in] .pull-who { opacity: 1; }
 .no-motion .pull-who { opacity: 1; }
 .lights-off .pull-who { color: #CBCDF7; }
-@media (max-width: 640px) { .pull-sticky { padding: 0 22px; } }
+@media (max-width: 640px) { .pull-scene { padding: 100px 22px; } }
 
 /* --------------------------------------------------------- photo band */
 
@@ -252,8 +254,6 @@ footer.chat-footer { border-top: 1px solid var(--rule); color: var(--faint); fon
   .hero h1 .w, .hero .cue { animation: none; opacity: 1; transform: none; }
   .hero h1 .dev::after { animation: none; }
   .qa .q, .qa .a { opacity: 1; animation: none; }
-  .pull-scene { height: auto; }
-  .pull-sticky { position: static; height: auto; padding: 70px 48px; }
   .pull-big, .pull-who { opacity: 1; transform: none; }
   .band img { transform: none; top: 0; height: 100%; }
   .hero .inner, .hero .ring { transform: none; opacity: 1; }
@@ -281,7 +281,7 @@ footer.chat-footer { border-top: 1px solid var(--rule); color: var(--faint); fon
   html { scroll-padding-top: 80px; }
   .cord .line { height: 40px; }
 
-  .hero { min-height: 88vh; padding: 130px 22px 30px; }
+  .hero { min-height: 88vh; padding: 130px 22px 60px; }
   .hero .ring { width: 140px; right: -6%; top: 3%; }
   .hero .cue { margin-top: 36px; }
   .rule-line { margin-top: 36px; width: 160px; }
@@ -301,8 +301,9 @@ footer.chat-footer { border-top: 1px solid var(--rule); color: var(--faint); fon
 
 /* -------------------------------------------------------- closing hint */
 
-.closing-hint { color: rgba(250,247,242,.65); font-size: .95rem; font-family: 'Fraunces', serif; font-style: italic; }
-.closing-hint a { color: #faf7f2; border-bottom: 1px solid #C68B4E; text-decoration: none; padding-bottom: 1px; }
+.closing-hint { color: rgba(250,247,242,.45); font-size: .82rem; font-family: 'Fraunces', serif; font-style: italic; margin-top: -14px; }
+.closing-hint a { color: rgba(250,247,242,.65); border-bottom: 1px solid rgba(198,139,78,.5); text-decoration: none; padding-bottom: 1px; }
+.closing-hint a:hover { color: #faf7f2; border-bottom-color: #C68B4E; }
 
 /* --------------------------------------------------------- coffee page */
 

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -10,7 +10,6 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Inter', Calibri, Candara, Segoe, "Segoe UI", Optima, Arial, sans-serif;
-  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }

--- a/src/hooks/useLights.ts
+++ b/src/hooks/useLights.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+const KEY = 'cb-lights'
+
+// Shared light-switch state, persisted so the easter egg survives navigation between pages.
+export function useLights() {
+  const [lights, setLights] = useState(() => localStorage.getItem(KEY) !== 'off')
+
+  useEffect(() => {
+    localStorage.setItem(KEY, lights ? 'on' : 'off')
+  }, [lights])
+
+  return [lights, setLights] as const
+}


### PR DESCRIPTION
## Summary
- Fixed a real bug: the Purple Room's scroll-pin reveal was broken by a global `overflow-x: hidden` (a classic CSS gotcha that silently breaks `position: sticky`), which also meant a full extra viewport of dead scrolling before reaching the resume. Replaced the fragile sticky mechanic with the same reveal-on-scroll pattern used elsewhere on the site.
- Dark mode now works on `/coffee` and `/uses` (previously light-only), with the preference persisted across pages.
- Dropped the cursive font swap on the name in dark mode for consistency; added more spacing between the hero and the first question; rewrote the coffee-cup HUD phrases; restructured the closing CTA and de-emphasized the coffee-log link relative to the main contact links.
- Made the roaster breakdown table collapsible again; added the espresso machine and other gear to the Kit; added a dedicated running question to the chat.

## Test plan
- [x] `npm run build` and `npm test` pass
- [x] Verified via CDP-driven headless browser (not just screenshots) that the sticky bug is fixed and no horizontal overflow was reintroduced by removing the global overflow-x rule, across `/`, `/coffee`, `/uses`, `/bar` at 375/768/1280/1920px
- [x] Verified dark mode toggles and persists correctly on `/coffee` and `/uses`
- [x] Verified live GitHub Pages build succeeded and is serving the current bundle